### PR TITLE
Ranked stats rough draft

### DIFF
--- a/src/pubg_clj/api.clj
+++ b/src/pubg_clj/api.clj
@@ -91,6 +91,9 @@
 (defn- season-stats-endpoint
   [player-id season-id]
   (str "players/" player-id "/seasons/" season-id))
+(defn- season-ranked-stats-endpoint
+  [player-id season-id]
+  (str "players/" player-id "/seasons/" season-id "/ranked"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Status
@@ -271,3 +274,18 @@
                       :endpoint (season-stats-endpoint id season-id)})
          :body
          p/player-season-stats-parse)))
+
+(defn fetch-player-season-ranked-stats
+  "Fetches the ranked season stats for a given player and season. The
+  region is required for PS4, Xbox, and for stats of PC players prior
+  to and including division.bro.official.2018-09. It is probably best
+  to always include the region, as the API will respond with stats for
+  EVERY region in the cases where it is depracated."
+  [player season-id & [region]]
+  (let [{:keys [pubg.player/id pubg/shard-id]} player]
+    (->> (pubg-fetch
+          {:platform shard-id,
+           :region (or region ""),
+           :endpoint (season-ranked-stats-endpoint id season-id)})
+         :body
+         p/player-season-ranked-stats-parse)))

--- a/src/pubg_clj/api.clj
+++ b/src/pubg_clj/api.clj
@@ -30,7 +30,7 @@
   (cond-> "https://api.pubg.com/"
     (or platform region) (concat "shards/")
     platform             (concat platform)
-    region               (concat "-" region)
+    ;; region               (concat "-" region)
     endpoint             (concat "/" endpoint)
     true str/join))
 

--- a/src/pubg_clj/api/parsers.clj
+++ b/src/pubg_clj/api/parsers.clj
@@ -174,6 +174,39 @@
    :pubg.season.stats/wins                   {:from [:wins]}
    })
 
+(defparser season-ranked-stats-parse
+ {:pubg/game-mode                         {:from [:game-mode]},
+  :pubg.season.stats/kills                {:from [:kills]},
+  :pubg.season.stats/kill-streak          {:from [:kill-streak]},
+  :pubg.season.stats/boosts               {:from [:boosts]},
+  :pubg.season.stats/team-kills           {:from [:team-kills]},
+  :pubg.season.stats/revives              {:from [:revives]},
+  :pubg.season.stats/assists              {:from [:assists]},
+  :pubg.season.stats/kdr                  {:from [:kdr]},
+  :pubg.season.stats/revive-ratio         {:from [:revive-ratio]},
+  :pubg.season.stats/avg-rank             {:from [:avg-rank]},
+  :pubg.season.stats/deaths               {:from [:deaths]},
+  :pubg.season.stats/damage-dealt         {:from [:damage-dealt]},
+  :pubg.season.stats/weapons-acquired     {:from [:weapons-acquired]},
+  :pubg.season.stats/heals                {:from [:heals]},
+  :pubg.season.stats/play-time            {:from [:play-time]},
+  :pubg.season.stats/top-10-ratio         {:from [:top-10-ratio]},
+  :pubg.season.stats/kda                  {:from [:kda]},
+  :pubg.season.stats/headshot-kill-ratio  {:from [:headshot-kill-ratio]},
+  :pubg.season.stats/current-rank-point   {:from [:current-rank-point]},
+  :pubg.season.stats/dbnos                {:from [:d-bn-os]},
+  :pubg.season.stats/best-tier            {:from [:best-tier :tier]},
+  :pubg.season.stats/avg-survival-time    {:from [:avg-survival-time]},
+  :pubg.season.stats/round-most-kills     {:from [:round-most-kills]},
+  :pubg.season.stats/headshot-kills       {:from [:headshot-kills]},
+  :pubg.season.stats/current-tier         {:from [:current-tier :tier]},
+  :pubg.season.stats/current-sub-tier     {:from [:current-tier :sub-tier]},
+  :pubg.season.stats/best-rank-point      {:from [:best-rank-point]},
+  :pubg.season.stats/longest-kill         {:from [:longest-kill]},
+  :pubg.season.stats/wins                 {:from [:wins]},
+  :pubg.season.stats/win-ratio            {:from [:win-ratio]},
+  :pubg.season.stats/rounds-played        {:from [:rounds-played]}})
+
 (defn- pack-game-mode-stats
   [[game-mode-key stats-map]]
   (assoc stats-map :game-mode (name game-mode-key)))
@@ -183,6 +216,13 @@
    :pubg.player/season-stats {:from [:data :attributes :game-mode-stats]
                               :using #(let [stats (map pack-game-mode-stats %)]
                                         (mapv season-stats-parse stats))}})
+
+(defparser
+ player-season-ranked-stats-parse
+ {:pubg.player/id     {:from [:data :relationships :player :data :id]},
+  :pubg.player/season-stats {:from [:data :attributes :game-mode-stats],
+                             :using #(let [stats (map pack-game-mode-stats %)]
+                                       (mapv season-ranked-stats-parse stats))}})
 
 (defparser telemetry-common-parse
   {:pubg.match.telemetry.common/is-game {:from [:is-game]}})
@@ -366,4 +406,3 @@
                                                maybe-discard (fn [x]
                                                                (if (map? x) (discard-nil-vals x) x))]
                                            (walk/postwalk maybe-discard evts))}})
-

--- a/src/pubg_clj/api/parsers.clj
+++ b/src/pubg_clj/api/parsers.clj
@@ -219,8 +219,8 @@
 
 (defparser
  player-season-ranked-stats-parse
- {:pubg.player/id     {:from [:data :relationships :player :data :id]},
-  :pubg.player/season-stats {:from [:data :attributes :game-mode-stats],
+ {:pubg.player/id                  {:from [:data :relationships :player :data :id]},
+  :pubg.player/season-ranked-stats {:from [:data :attributes :ranked-game-mode-stats]
                              :using #(let [stats (map pack-game-mode-stats %)]
                                        (mapv season-ranked-stats-parse stats))}})
 


### PR DESCRIPTION
This PR revisits #3 without a thrashed commit history or zprint-induced whitespace noise diffs.

I have been trying to get this to work for a couple of hours by stepping through a macroexpansion of `defparser` and manually testing a call to `fetch-player-season-ranked-stats`, but no luck so far. I could use some nudging toward a solution.

The standard unranked stats returned by `fetch-player-season-stats` looks like this.

```clj
{:body
   {:data {:attributes {
                        :game-mode-stats {:duo {
                                                :assists 0,
                                                :boosts 0,
                                                :d-bn-os 0,
                                                ...<SNIP>},
```

The ranked endpoint returns this:

```clj
{:body
   {:data {:attributes {
                        :ranked-game-mode-stats {:squad-fpp {
                                                             :assists 159,
                                                             :avg-rank 8.719444,
                                                             :avg-survival-time 0,
                                                             ...<SNIP>}}},
```

The shape of both structures is identical, which I have emphasized with some effort at alignment. From digging in `parsers.clj` I have concluded that `player-season-ranked-stats-parse` essentially just does a fancy call to `get-in`. It uses the vector value of `:from` to traverse the nested map and sets the value of each key in `season-stats-parse`, which again uses a `:from [:keys]` approach. It appears to not know anything more than the fact that `:game-mode-stats` is a key to a map containing relevant stats data. 

Given the fact that the ranked stats data has exactly the same shape, I would expect a first draft implementing ranked stats would be able to safely copy and paste the approach for unranked stats. However, the `:season-ranked-stats` key result is just an empty vector. I cannot understand why this happens. I'm traversing an identical data structure with an identical approach, but I capture no data.